### PR TITLE
[Add] READMEにER図のURLを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,7 @@
 ## 画面遷移図
 ---
 https://www.figma.com/file/tpd5guOIGeBcx2N1hK30O4/Wireframe?node-id=0%3A1
+
+## ER図
+---
+https://drive.google.com/file/d/1VuTSIdLMgvtgosmCS90aHUxXr0jZjm2B/view?usp=sharing


### PR DESCRIPTION
### 概要

READMEにER図のURLを追加。

### 確認方法

- 適切に正規化されたテーブル設計ができていることをご確認ください。

- アソシエーションの設定に過不足がないことをご確認ください。

- テーブル名やカラム名から保持しているデータが推測しやすい名前になっているかご確認ください。

### 補足情報

- `histories`テーブルに`history_age_id`カラムが存在しますが、このカラムにはRailsの[ActiveHash](https://github.com/zilkey/active_hash)を使って定義したデータの「ID」が入ります。

- ER図に`ActiveHash`という項目がありますが、こちらは`ActiveHash`でどのようにデータを定義するか一例として記載しております（添削の際に役立つのではないかと思い、追記しました）。なので、`ActiveHash`はテーブルでは無いということをご確認ください。（不要でしたらすいません！！）

### 懸念点

下記カラム名が保持しているデータを推測しづらい名前になっている気がしています。

1. `graphs`テーブルの`graph_age`カラム
→ こちらのカラムは「グラフ」を新規作成して、「詳細 or 編集」画面に遷移したい際に、何歳までのフォームを表示するか制御するための年齢のデータを持つカラムです。

2. `histories `テーブルの`history_age_id`カラム
→ こちらは`ActiveHash`で定義する情報のIDが保存されます。しかし、カラム名から推測しやすい名前になっているか自信がないです。
