### PR TITLE
[Fix] Herokuへのデプロイのため、DB設定を変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,7 +17,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
-  host: localhost
+  socket: /tmp/mysql.sock
 
 development:
   <<: *default

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
## 概要

- Heroku + MySQLでデプロイするため、DBの設定を修正

## 確認方法

- [ ] `socket`の設定が追加されていることをご確認ください。
- [ ] アセットのコンパイルができるように`config.assets.compile = true`が設定されていることをご確認ください。

## チェックリスト

プロジェクトごとにパスしなければならないルールは下記です。

- [ ] Rubocopのリントをパスしました。
- [ ]  rails_best_practiceのリントをパスしました。

