### PR TITLE
[Fix] HerokuデプロイのためDB設定を変更

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.3-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.3-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.5.6)
     oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
@@ -346,6 +348,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   active_hash

--- a/config/database.yml
+++ b/config/database.yml
@@ -51,6 +51,8 @@ test:
 #
 production:
   <<: *default
-  database: personal_history_production
-  username: personal_history
-  password: <%= ENV['PERSONAL_HISTORY_DATABASE_PASSWORD'] %>
+  database: <%= ENV['MYSQL_DATABASE'] %>
+  url: <%= ENV['MYSQL_URL'] %>
+  username: <%= ENV['MYSQL_USERNAME'] %>
+  password: <%= ENV['MYSQL_PASSWORD'] %>
+  host: <%= ENV['MYSQL_HOST'] %>


### PR DESCRIPTION
## 概要

- JawsDBというadd-onを使って、MySQLでHerokuデプロイするため、DB設定を変更。
- `git push heroku main`を実行した際の`Failed to install gems via Bundler.`エラーの対応。

## 確認方法

- [ ] `database.yml`ファイルのproduction環境が下記になっていることをご確認ください。

```ruby
database: <%= ENV['MYSQL_DATABASE'] %>
url: <%= ENV['MYSQL_URL'] %>
username: <%= ENV['MYSQL_USERNAME'] %>
password: <%= ENV['MYSQL_PASSWORD'] %>
host: <%= ENV['MYSQL_HOST'] %>
```

- [ ] `git push heroku main`コマンドを実行した際に、`Failed to install gems via Bundler.`というエラーが出たため、ログに従い`bundle lock --add-platform x86_64-linux`コマンドを実行。
そのため、`Gemfile.lock`にgemが追加されていることをご確認ください。

