### PR TITLE
[Add] uuidカラムの追加

### DIFF
--- a/app/models/my_history.rb
+++ b/app/models/my_history.rb
@@ -6,5 +6,7 @@ class MyHistory < ApplicationRecord
   validates :title, presence: true, length: { maximum: 50 }, allow_nil: true
   validates :user_id, uniqueness: true
 
+  before_create -> { self.uuid = SecureRandom.uuid }
+
   enum status: { published: 0, unpublished: 1 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,5 +14,8 @@ class User < ApplicationRecord
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
+  # before_createコールバックは、オブジェクトがDBに新規保存(saveメソッド：INSERT文)される直前で実行される
+  before_create -> { self.uuid = SecureRandom.uuid }
+
   enum gender: { men: 0, women: 1, other: 2, no_answer: 3 }
 end

--- a/db/migrate/20211214053143_add_uuid_columns_to_users_my_histories.rb
+++ b/db/migrate/20211214053143_add_uuid_columns_to_users_my_histories.rb
@@ -1,6 +1,8 @@
 class AddUuidColumnsToUsersMyHistories < ActiveRecord::Migration[6.0]
   def change
-    add_column :users, :uuid, :string, after: :id, null: false, unique: true
-    add_column :my_histories, :uuid, :string, after: :id, null: false, unique: true
+    add_column :users, :uuid, :string, after: :id, null: false
+    add_column :my_histories, :uuid, :string, after: :id, null: false
+    add_index :users, :uuid, unique: true
+    add_index :my_histories, :uuid, unique: true
   end
 end

--- a/db/migrate/20211214053143_add_uuid_columns_to_users_my_histories.rb
+++ b/db/migrate/20211214053143_add_uuid_columns_to_users_my_histories.rb
@@ -1,0 +1,6 @@
+class AddUuidColumnsToUsersMyHistories < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :uuid, :string, after: :id, null: false, unique: true
+    add_column :my_histories, :uuid, :string, after: :id, null: false, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2021_12_14_053143) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_my_histories_on_user_id", unique: true
+    t.index ["uuid"], name: "index_my_histories_on_uuid", unique: true
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
@@ -49,6 +50,7 @@ ActiveRecord::Schema.define(version: 2021_12_14_053143) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
+    t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
   add_foreign_key "events", "my_histories"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_21_054924) do
+ActiveRecord::Schema.define(version: 2021_12_14_053143) do
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "age", null: false
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2021_11_21_054924) do
   end
 
   create_table "my_histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
+    t.string "uuid", null: false
     t.integer "status", default: 0, null: false
     t.string "title"
     t.bigint "user_id", null: false
@@ -34,6 +35,7 @@ ActiveRecord::Schema.define(version: 2021_11_21_054924) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
+    t.string "uuid", null: false
     t.string "name", null: false
     t.string "email", null: false
     t.date "birthday"


### PR DESCRIPTION
## 概要

- `users`テーブルと`my_histories`テーブルに`uuid`カラムを追加
- ユーザー新規作成と自分史作成時に`uuid`カラムに一意なidが設定されるように修正

## 確認方法

> レビュー前に行ってほしいこと

- [ ] カラムを追加したので `bundle exec rails db:migrate` を実行してください

> レビュー依頼内容

- [ ] `users`テーブルと`my_histories`テーブルにuuidカラムが追加されていることをご確認ください。
- [ ] ユーザー新規作成と自分史作成時に`uuid`カラムに一意なidが設定されることをご確認ください。

## チェックリスト

プロジェクトごとにパスしなければならないルールは下記です。

- [ ] Rubocopのリントをパスしました。
- [ ]  rails_best_practiceのリントをパスしました。
