### PR TITLE
[Add] 自分史の編集画面と機能を追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,4 +53,4 @@ $fullhd: 1344px+(2 * $gap) !default;
 @import "bulma-extensions";
 @import "create_history";
 @import "timeline";
-@import "list_history"
+@import "list_history";

--- a/app/assets/stylesheets/parts.scss
+++ b/app/assets/stylesheets/parts.scss
@@ -20,7 +20,6 @@ $button-background-color: #ffe036;
 $button-background-color-sub1: #ffd803;
 $border-color: #d4e3f2;
 
-
 /*==================================
   base
 ==================================*/

--- a/app/assets/stylesheets/parts.scss
+++ b/app/assets/stylesheets/parts.scss
@@ -50,6 +50,27 @@ h1.ft-size-md {
   }
 }
 
+h1.title,
+h2.subtitle {
+  position: relative;
+  padding: 0 0 20px;
+}
+
+h1.title,
+h2.subtitle {
+  &::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    bottom: 0;
+    display: block;
+    width: 40px;
+    height: 5px;
+    background-color: #50C8A7;
+    margin-left: -20px;
+  }
+}
+
 /*========================================
   link
 ========================================*/

--- a/app/controllers/api/my_histories_controller.rb
+++ b/app/controllers/api/my_histories_controller.rb
@@ -15,9 +15,7 @@ class Api::MyHistoriesController < ApplicationController
 
   def update
     if @my_history.update(my_history_params)
-      respond_to do |format|
-        format.json { render json: { redirect: my_history_url(@my_history.uuid) } }
-      end
+      render json: @my_history, each_serializer: MyHistorySerializer, status: :ok
     else
       render json: { errors: @my_history.errors.keys.map { |key| [key, @my_history.errors.full_messages_for(key)]}.to_h }, status: :bad_request
     end
@@ -26,10 +24,10 @@ class Api::MyHistoriesController < ApplicationController
   private
 
   def set_my_history
-    @my_history = current_user.my_history;
+    @my_history = current_user.my_history
   end
 
   def my_history_params
-    params.require(:my_history).permit(:title, :status)
+    params.require(:my_history).permit(:title)
   end
 end

--- a/app/controllers/api/my_histories_controller.rb
+++ b/app/controllers/api/my_histories_controller.rb
@@ -16,7 +16,7 @@ class Api::MyHistoriesController < ApplicationController
   def update
     if @my_history.update(my_history_params)
       respond_to do |format|
-        format.json { render json: { redirect: my_history_url(@my_history) } }
+        format.json { render json: { redirect: my_history_url(@my_history.uuid) } }
       end
     else
       render json: { errors: @my_history.errors.keys.map { |key| [key, @my_history.errors.full_messages_for(key)]}.to_h }, status: :bad_request

--- a/app/controllers/api/my_histories_controller.rb
+++ b/app/controllers/api/my_histories_controller.rb
@@ -1,8 +1,12 @@
 class Api::MyHistoriesController < ApplicationController
-  before_action :set_my_history, only: %i[update]
+  before_action :set_my_history, only: %i[edit update]
+
+  def edit
+    render json: @my_history, each_serializer: MyHistorySerializer, include: %i[events], status: :ok
+  end
 
   def create
-    return render json: {:errors=>{:exists=>["既に自分史は作成済みです。"]}}, status: :bad_request if current_user.my_history.present?
+    return render json: { errors: { exists: ["既に自分史は作成済みです。"] } }, status: :bad_request if current_user.my_history.present?
 
     @my_history = current_user.build_my_history(my_history_params)
 

--- a/app/controllers/my_histories_controller.rb
+++ b/app/controllers/my_histories_controller.rb
@@ -12,6 +12,8 @@ class MyHistoriesController < ApplicationController
 
   def new; end
 
+  def edit; end
+
   def update
     if @my_history.update(my_history_params)
       render json: { redirect: my_history_url(@my_history.uuid) }

--- a/app/controllers/my_histories_controller.rb
+++ b/app/controllers/my_histories_controller.rb
@@ -1,6 +1,7 @@
 class MyHistoriesController < ApplicationController
   include Pagy::Backend
-  skip_before_action :require_login, only: [:index]
+  before_action :set_my_history, only: %i[update]
+  skip_before_action :require_login, only: %i[index]
 
   def index
     @q = MyHistory.ransack(params[:q])
@@ -10,4 +11,22 @@ class MyHistoriesController < ApplicationController
   def show; end
 
   def new; end
+
+  def update
+    if @my_history.update(my_history_params)
+      render json: { redirect: my_history_url(@my_history.uuid) }
+    else
+      render json: { errors: @my_history.errors.keys.map { |key| [key, @my_history.errors.full_messages_for(key)]}.to_h }, status: :bad_request
+    end
+  end
+
+  private
+
+  def set_my_history
+    @my_history = MyHistory.find(params[:id])
+  end
+
+  def my_history_params
+    params.require(:my_history).permit(:status)
+  end
 end

--- a/app/javascript/components/HistoryCard.vue
+++ b/app/javascript/components/HistoryCard.vue
@@ -3,7 +3,7 @@
     <div class="columns my-6 is-centered is-mobile">
       <div class="column pd-sm is-10-mobile is-three-quarters-tablet is-two-fifths-desktop is-two-thirds-widescreen is-half-fullhd">
         <h1 class="title has-text-centered mb-5">
-          自分史作成
+          {{ textJudgementFlag ? "自分史作成" : "自分史編集" }}
         </h1>
         <div class="card">
           <header class="card-header">
@@ -63,6 +63,13 @@
 <script>
 export default {
   name: "HistoryCard",
+  props: {
+    textJudgementFlag:
+    {
+      type: Boolean,
+      required: true,
+    },
+  },
   computed: {
     getUserProfile: function() {
       return this.$store.getters.getUserProfile;

--- a/app/javascript/components/HistoryCard.vue
+++ b/app/javascript/components/HistoryCard.vue
@@ -61,7 +61,6 @@
 </template>
 
 <script>
-
 export default {
   name: "HistoryCard",
   computed: {

--- a/app/javascript/components/PersonalHistory.vue
+++ b/app/javascript/components/PersonalHistory.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <history-card
+      :text-judgement-flag="textJudgementFlag"
       @myHistoryFlagChange="myHistoryFlagChange"
       @editMyHistoryFlagChange="editMyHistoryFlagChange"
       @addEventFlagChange="addEventFlagChange"
@@ -30,6 +31,7 @@
     />
     <time-line
       v-if="timeLineFlag"
+      :text-judgement-flag="textJudgementFlag"
       @editEventFlagChange="editEventFlagChange"
       @deleteEventSuccess="changeTimeLineFlag"
     />
@@ -69,6 +71,7 @@ export default {
       timeLineFlag: false,
       addEventFlag: false,
       editEventFlag: false,
+      textJudgementFlag: true,
       event: {
         data: {},
         key: null,
@@ -95,6 +98,7 @@ export default {
       this.$store.dispatch("getMyHistory").then(() => {
         this.changeTimeLineFlag();
       });
+      this.textJudgementFlag = false;
     }
 
     this.$store.dispatch("getUserProfile").then(() => {

--- a/app/javascript/components/PersonalHistory.vue
+++ b/app/javascript/components/PersonalHistory.vue
@@ -88,6 +88,15 @@ export default {
     },
   },
   mounted() {
+    // 新規作成 or 編集で取得するデータを変える
+    let last_path_name = window.location.pathname.split("/").pop();
+    if(last_path_name === "edit"){
+      // 自分史の情報とイベント情報
+      this.$store.dispatch("getMyHistory").then(() => {
+        this.changeTimeLineFlag();
+      });
+    }
+
     this.$store.dispatch("getUserProfile").then(() => {
       this.profileAndTitleModalFlagChange();
     });

--- a/app/javascript/components/TimeLine.vue
+++ b/app/javascript/components/TimeLine.vue
@@ -129,7 +129,7 @@
           <input
             type="submit"
             name="commit"
-            value="自分史作成"
+            :value="testSelect"
             class="button is-btn-yellow btn-design has-text-weight-semibold"
             @click="editStatus"
           >
@@ -145,6 +145,13 @@ import axios from "axios";
 
 export default {
   name: "TimeLine",
+  props: {
+    textJudgementFlag:
+    {
+      type: Boolean,
+      required: true,
+    },
+  },
   data() {
     return {
       editMyHistory: {
@@ -160,6 +167,9 @@ export default {
     },
     getMyHistory: function() {
       return this.$store.getters.getMyHistory;
+    },
+    testSelect: function() {
+      return this.textJudgementFlag ? "自分史作成" : "自分史更新";
     }
   },
   created() {

--- a/app/javascript/components/TimeLine.vue
+++ b/app/javascript/components/TimeLine.vue
@@ -129,7 +129,7 @@
           <input
             type="submit"
             name="commit"
-            :value="testSelect"
+            :value="textSelect"
             class="button is-btn-yellow btn-design has-text-weight-semibold"
             @click="editStatus"
           >
@@ -168,7 +168,7 @@ export default {
     getMyHistory: function() {
       return this.$store.getters.getMyHistory;
     },
-    testSelect: function() {
+    textSelect: function() {
       return this.textJudgementFlag ? "自分史作成" : "自分史更新";
     }
   },

--- a/app/javascript/components/TimeLine.vue
+++ b/app/javascript/components/TimeLine.vue
@@ -195,7 +195,7 @@ export default {
     },
     editStatus() {
       axios
-        .patch("/api/my_history", {
+        .patch(`/my_histories/${this.editMyHistory.id}`, {
           status: this.editMyHistory.status,
         })
         .then((json) => {

--- a/app/javascript/store/store.js
+++ b/app/javascript/store/store.js
@@ -49,6 +49,21 @@ export default new Vuex.Store({
         state.events[age]["data"].push(event);
       }
     },
+    setEventEdit(state, events) {
+      for (let i = 0; i < events.length; i++){
+        let event = events[i];
+        const age = event.age.toString();
+
+        if (Object.keys(state.events).includes(age)) {
+          state.events[age].data.push(event);
+        } else {
+          Vue.set(state.events, age, {});
+          state.events[age]["age"] = age;
+          Vue.set(state.events[age], "data", []);
+          state.events[age]["data"].push(event);
+        }
+      }
+    },
     editEvent(state, { event, key, index }) {
       let age = event.age.toString();
 
@@ -84,6 +99,20 @@ export default new Vuex.Store({
     },
   },
   actions: {
+    // 自分史とイベントを取得
+    getMyHistory({ commit }) {
+      return new Promise((resolve) => {
+        axios.get("/api/my_history/edit").then((response) => {
+          let my_history = {};
+          my_history["id"] = response.data.id;
+          my_history["status"] = response.data.status;
+          my_history["title"] = response.data.title;
+          commit("setEventEdit", response.data.events);
+          commit("setMyHistory", my_history);
+          resolve();
+        });
+      });
+    },
     // プロフィールを取得
     getUserProfile({ commit }) {
       return new Promise((resolve) => {
@@ -217,19 +246,19 @@ export default new Vuex.Store({
     },
   },
   getters: {
-    getUserProfile: function(state) {
+    getUserProfile: function (state) {
       return state.profile;
     },
-    getCategory: function(state) {
+    getCategory: function (state) {
       return state.category;
     },
-    getMyHistory: function(state) {
+    getMyHistory: function (state) {
       return state.my_history;
     },
-    getEvents: function(state) {
+    getEvents: function (state) {
       return state.events;
     },
-    getEventsCount: function(state) {
+    getEventsCount: function (state) {
       return Object.keys(state.events).length;
     },
   },

--- a/app/serializers/my_history_serializer.rb
+++ b/app/serializers/my_history_serializer.rb
@@ -1,3 +1,5 @@
 class MyHistorySerializer < ActiveModel::Serializer
   attributes :id, :status, :title
+  # 関連モデルのオブジェクトも取得
+  has_many :events
 end

--- a/app/views/my_histories/_my_history.html.erb
+++ b/app/views/my_histories/_my_history.html.erb
@@ -1,6 +1,6 @@
 <article class="post">
   <h3>
-    <%= link_to my_history.title, "#", class: "history_title" %>
+    <%= link_to my_history.title, my_history_path(my_history.uuid), class: "history_title" %>
   </h3>
   <div class="media">
     <div class="media-left">

--- a/app/views/my_histories/edit.html.erb
+++ b/app/views/my_histories/edit.html.erb
@@ -1,0 +1,6 @@
+<% content_for(:title, t(".title")) %>
+<main class="wrap-content">
+  <div id="app"></div>
+</main>
+
+<%= javascript_pack_tag "main" %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -33,6 +33,8 @@ ja:
       no_result: "自分史はありません。"
     new:
       title: "自分史作成"
+    edit:
+      title: "自分史編集"
   profiles:
     edit:
       title: "プロフィール編集"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,12 +10,12 @@ Rails.application.routes.draw do
   # プロフィール関係
   resource :profile, only: %i[show edit update]
   # 自分史関係
-  resources :my_histories, only: %i[index new show update]
+  resources :my_histories, only: %i[index show new edit update]
   # API通信関係
   namespace :api, {format: "json"} do
     resource :profile, only: %i[show update]
     resources :categories, only: %i[index]
     resources :events, only: %i[create update destroy]
-    resource :my_history, only: %i[create update]
+    resource :my_history, only: %i[edit create update]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   # プロフィール関係
   resource :profile, only: %i[show edit update]
   # 自分史関係
-  resources :my_histories, only: %i[index new show]
+  resources :my_histories, only: %i[index new show update]
   # API通信関係
   namespace :api, {format: "json"} do
     resource :profile, only: %i[show update]

--- a/db/seeds/my_histories.rb
+++ b/db/seeds/my_histories.rb
@@ -2,6 +2,7 @@ puts "my_histories ..."
 
 User.all.each_with_index do |user, i|
   user.create_my_history!(
+    uuid: SecureRandom.uuid,
     status: Faker::Number.between(from: 0, to: 1),
     title: "タイトル_#{ i + 1 }",
   )

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -2,6 +2,7 @@ puts "users ..."
 
 150.times do |n|
   User.create!(
+    uuid: SecureRandom.uuid,
     name: "user_#{ n + 1 }",
     email: "sample_#{ n + 1 }@example.com",
     birthday: Faker::Date.between(from: "1923-04-01", to: "2007-04-01"),


### PR DESCRIPTION
## 概要

- 自分史編集画面を作成
- 自分史編集機能を作成

## 確認方法

> 自分史編集画面

[![Image from Gyazo](https://i.gyazo.com/84f8d36dbe1afb58507e466cd03d5555.png)](https://gyazo.com/84f8d36dbe1afb58507e466cd03d5555)
[![Image from Gyazo](https://i.gyazo.com/ae49fc615c5470baa1dac7e1f06d7089.png)](https://gyazo.com/ae49fc615c5470baa1dac7e1f06d7089)

- [ ] 自分史作成画面が上記画像のように表示されることをご確認ください。
- [ ] 自分史作成時は「自分史作成」というタイトルと「自分史作成」というボタンが表示されますが、編集時は「自分史編集」というタイトルと「更新」というボタンが表示されていることをご確認ください。

> 機能

- [ ] 自分史編集機能では、「ユーザーのプロフィール編集モーダル」や「自分史作成のタイトル入力モーダル」が表示されないことをご確認ください。
- [ ] 「タイトル編集」ボタンからタイトルが編集できることをご確認ください。
- [ ] 「イベント追加」ボタンからイベントが追加できることをご確認ください。
- [ ] 既存のイベント編集ボタンからイベントが編集できることをご確認ください。
- [ ] 既存のイベント削除ボタンからイベントが削除できることをご確認ください。
- [ ] 「公開 / 非公開」設定を選択後、「更新」ボタンをクリックすると更新が完了して、自分史詳細画面に遷移することをご確認ください。

> その他

- [ ] seedでデータを保存する際に、`uuid`カラムにもデータを保存するためにコードを追加しました。

## チェックリスト

プロジェクトごとにパスしなければならないルールは下記です。

- [ ]  Rubocopのリントをパスしました。
- [ ]  rails_best_practiceのリントをパスしました。

## コメント

「自分史編集画面」は「自分史作成画面」を併用しています。